### PR TITLE
Fix/#11 add posts list in thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@tanstack/react-query": "^4.24.4",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -4,18 +4,23 @@ import { ThreadsListContainer } from './ThreadsListCotainer';
 import { NewThreadForm } from './NewThreadForm';
 import { PostsListContainer } from './PostsListContainer';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { THREAD, POST } from './Routes';
 import './App.css';
 
+const queryClient = new QueryClient();
+
 export const App = () => {
   return (
-    <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path={THREAD.INDEX_PATH} element={<ThreadsListContainer />} />
-        <Route path={THREAD.NEW_PATH} element={<NewThreadForm />} />
-        <Route path={POST.INDEX_PATH} element={<PostsListContainer />} />
-      </Routes>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Header />
+        <Routes>
+          <Route path={THREAD.INDEX_PATH} element={<ThreadsListContainer />} />
+          <Route path={THREAD.NEW_PATH} element={<NewThreadForm />} />
+          <Route path={POST.INDEX_PATH} element={<PostsListContainer />} />
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 };

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -124,38 +124,41 @@ describe('Posts index', () => {
 
   beforeEach(() => {
     state = {
-      posts: [
+      status: 'success',
+      data: [
         { id: '123abcde-0000-123a-456b-abcde12345', post: 'Post 1' },
         { id: '456abcde-0000-234b-789c-bcdef23456', post: 'Post 2' },
       ],
-      loading: false,
       error: null,
     };
   });
 
   test('verfy "Loading..." message if in loading state', () => {
-    state.loading = true;
-    const { getByText } = render(<Posts state={state} />);
+    state.status = 'loading';
+    const { getByText } = render(<Posts {...state} />);
     expect(getByText('Loading...')).toBeInTheDocument();
   });
 
   test('verify Error message if has error state', () => {
-    state.error = 'Error';
-    const { getByText } = render(<Posts state={state} />);
-    expect(getByText('エラーが発生しました')).toBeInTheDocument();
+    state.error = { message: 'Error' };
+    state.status = 'error';
+    const { getByText } = render(<Posts {...state} />);
+    expect(
+      getByText('エラーが発生しました。エラー内容：Error'),
+    ).toBeInTheDocument();
   });
 
   test('verify NoPosts message if posts is empty', () => {
-    state.posts = [];
-    const { getByText } = render(<Posts state={state} />);
+    state.data = [];
+    const { getByText } = render(<Posts {...state} />);
     expect(
       getByText('このスレッドにはまだコメントがありません'),
     ).toBeInTheDocument();
   });
 
   test('verify PostsList is exist', () => {
-    const { getByText } = render(<Posts state={state} />);
-    for (const post of state.posts) {
+    const { getByText } = render(<Posts {...state} />);
+    for (const post of state.data) {
       expect(getByText(post.post)).toBeInTheDocument();
     }
   });

--- a/src/Posts.js
+++ b/src/Posts.js
@@ -1,19 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const Posts = ({ state }) => {
+export const Posts = ({ status, data, error }) => {
   return (
     <>
-      {state.loading && <Loading />}
-      {state.error && <Error />}
-      {state.posts && !state.posts.length && <NoPosts />}
-      {state.posts && <PostsList posts={state.posts} />}
+      {status === 'loading' && <Loading />}
+      {status === 'error' && <Error error={error.message} />}
+      {status === 'success' && !data.length && <NoPosts />}
+      {status === 'success' && <PostsList posts={data} />}
     </>
   );
 };
 
 const Loading = () => <div className="center">Loading...</div>;
-const Error = () => <div className="center">エラーが発生しました</div>;
+const Error = ({ error }) => (
+  <div className="center">エラーが発生しました。エラー内容：{error}</div>
+);
 const NoPosts = () => (
   <div className="center">このスレッドにはまだコメントがありません</div>
 );
@@ -37,5 +39,13 @@ PostsList.propTypes = {
 };
 
 Posts.propTypes = {
-  state: PropTypes.object.isRequired,
+  status: PropTypes.oneOf(['loading', 'error', 'success']).isRequired,
+  data: PropTypes.array,
+  error: PropTypes.shape({
+    message: PropTypes.string,
+  }),
+};
+
+Error.propTypes = {
+  error: PropTypes.string.isRequired,
 };

--- a/src/PostsListContainer.js
+++ b/src/PostsListContainer.js
@@ -52,12 +52,11 @@ const useFetchPosts = (threadId) => {
 export const PostsListContainer = () => {
   const location = useLocation();
   const threadId = location.state.threadId;
-  const threadTitle = location.state.threadTitle;
   const state = useFetchPosts(threadId);
 
   return (
     <main className="main">
-      <h3>タイトル：{threadTitle}</h3>
+      <h3>全てのコメント</h3>
       <Posts state={state} />
     </main>
   );

--- a/src/PostsListContainer.js
+++ b/src/PostsListContainer.js
@@ -1,62 +1,36 @@
-import React, { useReducer } from 'react';
+import React from 'react';
 import axios from 'axios';
 import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { Posts } from './Posts';
 const baseUrl = process.env.REACT_APP_BASEURL;
 
-const postsListReducer = (state, action) => {
-  switch (action.type) {
-    case 'SUCCESS':
-      return {
-        ...state,
-        posts: action.payload.posts,
-        loading: false,
-        error: null,
-      };
-    case 'ERROR':
-      return {
-        ...state,
-        loading: false,
-        error: action.payload.error,
-      };
-    default:
-      return state;
-  }
-};
-
-const useFetchPosts = (threadId) => {
-  const [state, dispatch] = useReducer(postsListReducer, {
-    posts: null,
-    loading: true,
-    error: null,
-  });
-  React.useEffect(() => {
-    axios
-      .get(`${baseUrl}/threads/${threadId}/posts?offset=0`)
-      .then((res) => {
-        dispatch({
-          type: 'SUCCESS',
-          payload: { posts: res.data.posts || [] },
-        });
-      })
-      .catch((error) => {
-        dispatch({
-          type: 'ERROR',
-          payload: { error },
-        });
-      });
-  }, [threadId]);
-  return state;
-};
-
 export const PostsListContainer = () => {
   const { threadId } = useParams();
-  const state = useFetchPosts(threadId);
+
+  // useQueryを使ってAPIデータを取得する
+  const {
+    status,
+    data = [],
+    error,
+  } = useQuery(
+    ['posts', threadId],
+    async () => {
+      const res = await axios.get(
+        `${baseUrl}/threads/${threadId}/posts?offset=0`,
+      );
+      return res.data.posts || [];
+    },
+    {
+      // cacheTimeにキャッシュ時間を設定する。5分
+      cacheTime: 5 * 60 * 1000,
+    },
+  );
 
   return (
     <main className="main">
       <h3>全てのコメント</h3>
-      <Posts state={state} />
+      <Posts status={status} data={data} error={error} />
     </main>
   );
 };

--- a/src/PostsListContainer.js
+++ b/src/PostsListContainer.js
@@ -1,6 +1,6 @@
 import React, { useReducer } from 'react';
 import axios from 'axios';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { Posts } from './Posts';
 const baseUrl = process.env.REACT_APP_BASEURL;
 
@@ -50,8 +50,7 @@ const useFetchPosts = (threadId) => {
 };
 
 export const PostsListContainer = () => {
-  const location = useLocation();
-  const threadId = location.state.threadId;
+  const { threadId } = useParams();
   const state = useFetchPosts(threadId);
 
   return (

--- a/src/Threads.js
+++ b/src/Threads.js
@@ -9,7 +9,7 @@ export const Threads = ({ threads }) => {
         <li className="thread_title" key={thread.id}>
           <Link
             to={`/threads/${thread.id}/posts`}
-            state={{ threadId: thread.id, threadTitle: thread.title }}
+            state={{ threadId: thread.id }}
             className="thread_link"
           >
             {thread.title}

--- a/src/Threads.js
+++ b/src/Threads.js
@@ -7,11 +7,7 @@ export const Threads = ({ threads }) => {
     <ul className="thread_list">
       {threads.map((thread) => (
         <li className="thread_title" key={thread.id}>
-          <Link
-            to={`/threads/${thread.id}/posts`}
-            state={{ threadId: thread.id }}
-            className="thread_link"
-          >
+          <Link to={`/threads/${thread.id}/posts`} className="thread_link">
             {thread.title}
           </Link>
         </li>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,6 +1752,19 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@tanstack/query-core@4.24.4":
+  version "4.24.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.24.4.tgz#6fe78777286fdd805ac319c7c743df4935e18ee2"
+  integrity sha512-9dqjv9eeB6VHN7lD3cLo16ZAjfjCsdXetSAD5+VyKqLUvcKTL0CklGQRJu+bWzdrS69R6Ea4UZo8obHYZnG6aA==
+
+"@tanstack/react-query@^4.24.4":
+  version "4.24.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.24.4.tgz#79e892edac33d8aa394795390c0f79e4a8c9be4d"
+  integrity sha512-RpaS/3T/a3pHuZJbIAzAYRu+1nkp+/enr9hfRXDS/mojwx567UiMksoqW4wUFWlwIvWTXyhot2nbIipTKEg55Q==
+  dependencies:
+    "@tanstack/query-core" "4.24.4"
+    use-sync-external-store "^1.2.0"
+
 "@testing-library/dom@^8.5.0":
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.0.tgz#914aa862cef0f5e89b98cc48e3445c4c921010f6"
@@ -8889,6 +8902,11 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## 概要

- threadIdパラメータの取得方法をuseParamsに変更
- TanStack Query(React Query)を導入

## 目的

- 投稿一覧画面でURLを直打ちした場合、投稿一覧画面が表示されないバグを修正するため
- APIの取得をキャッシュし表示速度を上げることでパフォーマンスを改善するため

## 参考URL：

https://reactrouter.com/en/main/hooks/use-params
https://tanstack.com/query/v4/docs/react/guides/caching


