### PR TITLE
Feature/#4_add_message_sending_form

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -26,4 +26,3 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Apply Code Formatter Change
-          commit_all: true

--- a/src/App.css
+++ b/src/App.css
@@ -27,7 +27,7 @@
   text-align: center;
   margin: auto;
   max-width: 600px;
-  min-width: 300px;
+  min-width: 900px;
 }
 
 .thread_list {
@@ -97,17 +97,41 @@ button:disabled {
   color: black;
 }
 
-.input {
+.commentform>textarea {
+  width: 400px;
+  height: 100px;
+  padding: 10px;
+  font-size: 20px;
+  margin: 10px;
+  border: 1px solid #565656;
+  border-radius: 10px;
+  margin-top: 73px;
+}
+
+.buttonwrap {
+  text-align: center;
+  padding: 20px 0;
+}
+
+input[type="submit"] {
   width: 100px;
-  margin-left: 50%;
   font-size: 20px;
   color: #ffffff;
+  /* margin-left: 50%; */
   background-color: #66d48b;
   border-radius: 10px;
   border: 1px solid #565656;
 }
 
-input:disabled {
+/* input[type="reset"] {
+  width: 100px;
+  font-size: 20px;
+  color: black;
+  border-radius: 10px;
+  border: 1px solid #565656;
+} */
+
+input[type="submit"]:disabled {
   background-color: gray;
   color: black;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -97,6 +97,11 @@ button:disabled {
   color: black;
 }
 
+input:disabled {
+  background-color: gray;
+  color: black;
+}
+
 p {
   color: red;
   font-size: small;

--- a/src/App.css
+++ b/src/App.css
@@ -97,7 +97,7 @@ button:disabled {
   color: black;
 }
 
-.commentform>textarea {
+.commentform > textarea {
   width: 400px;
   height: 100px;
   padding: 10px;
@@ -113,25 +113,25 @@ button:disabled {
   padding: 20px 0;
 }
 
-input[type="submit"] {
+input[type='submit'] {
   width: 100px;
   font-size: 20px;
   color: #ffffff;
-  /* margin-left: 50%; */
+  margin-left: 50%;
   background-color: #66d48b;
   border-radius: 10px;
   border: 1px solid #565656;
 }
 
-/* input[type="reset"] {
+input[type='reset'] {
   width: 100px;
   font-size: 20px;
   color: black;
   border-radius: 10px;
   border: 1px solid #565656;
-} */
+}
 
-input[type="submit"]:disabled {
+input[type='submit']:disabled {
   background-color: gray;
   color: black;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -97,6 +97,16 @@ button:disabled {
   color: black;
 }
 
+.input {
+  width: 100px;
+  margin-left: 50%;
+  font-size: 20px;
+  color: #ffffff;
+  background-color: #66d48b;
+  border-radius: 10px;
+  border: 1px solid #565656;
+}
+
 input:disabled {
   background-color: gray;
   color: black;

--- a/src/App.css
+++ b/src/App.css
@@ -101,3 +101,8 @@ p {
   color: red;
   font-size: small;
 }
+
+.post-form {
+  display: flex;
+  flex-direction: row;
+}

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -8,6 +8,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
   const {
     register,
     handleSubmit,
+    reset,
     setError,
     formState: { errors },
   } = useForm();
@@ -47,6 +48,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
         },
       );
       if (response.status === 200) {
+        reset({ posts: '' });
         fetchPostsList();
       }
     } catch (err) {
@@ -68,22 +70,24 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
         {...register('posts', {
           required: true,
           maxLength: 140,
+          // 空白文字だけでは投稿できない。文字と文字の間の空白は許可。改行も許可
+          pattern: /^[\S][\s\S]*[\S]$/,
         })}
         placeholder="投稿しよう!"
         onChange={onChangePost}
       />
-      <div>
-        <button
-          type="submit"
-          className="button"
-          disabled={Boolean(errors?.posts?.type)}
-        >
-          投稿
-        </button>
-      </div>
+      <input
+        type="submit"
+        disabled={Boolean(errors?.posts?.type)}
+        value="投稿"
+        className="button"
+      />
       {errors?.posts?.type === 'required' && <p>投稿を入力してください</p>}
       {errors?.posts?.type === 'maxLength' && (
         <p>文字数は140文字以下にしてください</p>
+      )}
+      {errors?.posts?.type === 'pattern' && (
+        <p>先頭と文末の空白文字を削除してください</p>
       )}
     </form>
   );

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -13,21 +13,6 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
     formState: { errors },
   } = useForm();
 
-  // タイトル入力時に実行されるバリデーション
-  const onChangePost = useCallback((e) => {
-    const texts = e.target.value;
-    // 140文字のバリデーションは暫定対応。仕様確定後に修正。
-    if (texts.length > 140) {
-      setError('posts', {
-        type: 'maxLength',
-      });
-    } else {
-      setError('posts', {
-        type: '',
-      });
-    }
-  }, []);
-
   const onSubmit = useCallback(async (data) => {
     if (!data.posts.trim()) {
       setError('posts', {
@@ -78,7 +63,6 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
           maxLength: 140,
         })}
         placeholder="投稿しよう!"
-        onChange={onChangePost}
       />
       <div className="buttonwrap">
         <input type="reset" value="リセット" />

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -13,6 +13,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
     formState: { errors },
   } = useForm();
 
+  // 送信時に実行されるバリデーション＆例外処理
   const onSubmit = useCallback(async (data) => {
     if (!data.posts.trim()) {
       setError('posts', {

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -37,7 +37,7 @@ export const CommentForm = ({ threadId }) => {
       const response = await axios.post(
         `${baseUrl}/threads/${threadId}/posts`,
         {
-          posts: data.posts.trim(),
+          post: data.posts.trim(),
         },
         {
           headers: {

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { useForm } from 'react-hook-form';
 const baseUrl = process.env.REACT_APP_BASEURL;
 
-export const CommentForm = ({ threadId }) => {
+export const CommentForm = ({ threadId, fetchPostsList }) => {
   const {
     register,
     handleSubmit,
@@ -47,7 +47,7 @@ export const CommentForm = ({ threadId }) => {
         },
       );
       if (response.status === 200) {
-        window.location.reload();
+        fetchPostsList();
       }
     } catch (err) {
       let errorMessage = '';
@@ -91,4 +91,5 @@ export const CommentForm = ({ threadId }) => {
 
 CommentForm.propTypes = {
   threadId: PropTypes.string.isRequired,
+  fetchPostsList: PropTypes.func.isRequired,
 };

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -13,6 +13,16 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
     formState: { errors },
   } = useForm();
 
+  const handleError = (err) => {
+    let errorMessage = '';
+    if (err.response) {
+      errorMessage = err.response.data.ErrorMessageJP;
+    } else {
+      errorMessage = 'Unknown Error';
+    }
+    console.error(errorMessage);
+  };
+
   // 送信時に実行されるバリデーション＆例外処理
   const onSubmit = useCallback(async (data) => {
     if (!data.posts.trim()) {
@@ -39,14 +49,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
         fetchPostsList();
       }
     } catch (err) {
-      let errorMessage = '';
-      if (err.response) {
-        errorMessage = err.response.data.ErrorMessageJP;
-        console.error(errorMessage);
-      } else {
-        errorMessage = 'Unknown Error';
-        console.error(errorMessage);
-      }
+      handleError(err);
     }
   }, []);
 

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -47,6 +47,12 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
           },
         },
       );
+      if (data.posts.trim() === '') {
+        setError('posts', {
+          type: 'required',
+        });
+        return;
+      }
       if (response.status === 200) {
         reset({ posts: '' });
         fetchPostsList();
@@ -70,8 +76,6 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
         {...register('posts', {
           required: true,
           maxLength: 140,
-          // 空白文字だけでは投稿できない。文字と文字の間の空白は許可。改行も許可
-          pattern: /^[\S][\s\S]*[\S]$/,
         })}
         placeholder="投稿しよう!"
         onChange={onChangePost}
@@ -85,9 +89,6 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
       {errors?.posts?.type === 'required' && <p>投稿を入力してください</p>}
       {errors?.posts?.type === 'maxLength' && (
         <p>文字数は140文字以下にしてください</p>
-      )}
-      {errors?.posts?.type === 'pattern' && (
-        <p>先頭と文末の空白文字を削除してください</p>
       )}
     </form>
   );

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { PropTypes } from 'prop-types';
+import axios from 'axios';
+const baseUrl = process.env.REACT_APP_BASEURL;
+
+export const CommentForm = ({ threadId }) => {
+  const [posts, setPosts] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await axios.post(
+        `${baseUrl}/threads/${threadId}/posts`,
+        {
+          post: posts,
+        },
+        {
+          headers: {
+            accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      if (response.status === 200) {
+        window.location.reload();
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <textarea
+        placeholder="投稿しよう!"
+        value={posts}
+        onChange={(e) => setPosts(e.target.value)}
+      />
+      <div>
+        <button type="submit" className="button">
+          投稿
+        </button>
+      </div>
+    </form>
+  );
+};
+
+CommentForm.propTypes = {
+  threadId: PropTypes.string.isRequired,
+};

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -18,6 +18,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
       setError('posts', {
         type: 'required',
       });
+      return;
     }
     try {
       const response = await axios.post(

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -84,7 +84,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
         type="submit"
         disabled={Boolean(errors?.posts?.type)}
         value="投稿"
-        className="button"
+        className="input"
       />
       {errors?.posts?.type === 'required' && <p>投稿を入力してください</p>}
       {errors?.posts?.type === 'maxLength' && (

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -81,7 +81,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
         onChange={onChangePost}
       />
       <div className="buttonwrap">
-        {/* <input type="reset" value="リセット" /> */}
+        <input type="reset" value="リセット" />
         <input
           type="submit"
           disabled={Boolean(errors?.posts?.type)}

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { useForm } from 'react-hook-form';
 const baseUrl = process.env.REACT_APP_BASEURL;
 
-export const CommentForm = ({ threadId, fetchPostsList }) => {
+export const CommentForm = ({ threadId, updatePostsList }) => {
   const {
     register,
     handleSubmit,
@@ -46,7 +46,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
       );
       if (response.status === 200) {
         reset({ posts: '' });
-        fetchPostsList();
+        updatePostsList();
       }
     } catch (err) {
       handleError(err);
@@ -81,5 +81,5 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
 
 CommentForm.propTypes = {
   threadId: PropTypes.string.isRequired,
-  fetchPostsList: PropTypes.func.isRequired,
+  updatePostsList: PropTypes.func.isRequired,
 };

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -33,12 +33,6 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
           },
         },
       );
-      if (data.posts.trim() === '') {
-        setError('posts', {
-          type: 'required',
-        });
-        return;
-      }
       if (response.status === 200) {
         reset({ posts: '' });
         fetchPostsList();

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -1,18 +1,43 @@
-import React, { useState } from 'react';
+import React, { useCallback } from 'react';
 import { PropTypes } from 'prop-types';
 import axios from 'axios';
+import { useForm } from 'react-hook-form';
 const baseUrl = process.env.REACT_APP_BASEURL;
 
 export const CommentForm = ({ threadId }) => {
-  const [posts, setPosts] = useState('');
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm();
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+  // タイトル入力時に実行されるバリデーション
+  const onChangePost = useCallback((e) => {
+    const texts = e.target.value;
+    // 140文字のバリデーションは暫定対応。仕様確定後に修正。
+    if (texts.length > 140) {
+      setError('posts', {
+        type: 'maxLength',
+      });
+    } else {
+      setError('posts', {
+        type: '',
+      });
+    }
+  }, []);
+
+  const onSubmit = useCallback(async (data) => {
+    if (!data.posts.trim()) {
+      setError('posts', {
+        type: 'required',
+      });
+    }
     try {
       const response = await axios.post(
         `${baseUrl}/threads/${threadId}/posts`,
         {
-          post: posts,
+          posts: data.posts.trim(),
         },
         {
           headers: {
@@ -24,23 +49,42 @@ export const CommentForm = ({ threadId }) => {
       if (response.status === 200) {
         window.location.reload();
       }
-    } catch (error) {
-      console.error(error);
+    } catch (err) {
+      let errorMessage = '';
+      if (err.response) {
+        errorMessage = err.response.data.ErrorMessageJP;
+        console.error(errorMessage);
+      } else {
+        errorMessage = 'Unknown Error';
+        console.error(errorMessage);
+      }
     }
-  };
+  }, []);
 
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <textarea
+        name="posts"
+        {...register('posts', {
+          required: true,
+          maxLength: 140,
+        })}
         placeholder="投稿しよう!"
-        value={posts}
-        onChange={(e) => setPosts(e.target.value)}
+        onChange={onChangePost}
       />
       <div>
-        <button type="submit" className="button">
+        <button
+          type="submit"
+          className="button"
+          disabled={Boolean(errors?.posts?.type)}
+        >
           投稿
         </button>
       </div>
+      {errors?.posts?.type === 'required' && <p>投稿を入力してください</p>}
+      {errors?.posts?.type === 'maxLength' && (
+        <p>文字数は140文字以下にしてください</p>
+      )}
     </form>
   );
 };

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -55,7 +55,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
         name="posts"
         {...register('posts', {
           required: true,
-          maxLength: 140,
+          maxLength: 140, // 最大文字数は暫定対応。仕様確定後に修正
         })}
         placeholder="投稿しよう!"
       />

--- a/src/CommentForm.js
+++ b/src/CommentForm.js
@@ -70,7 +70,7 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
   }, []);
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit)} className="commentform">
       <textarea
         name="posts"
         {...register('posts', {
@@ -80,12 +80,14 @@ export const CommentForm = ({ threadId, fetchPostsList }) => {
         placeholder="投稿しよう!"
         onChange={onChangePost}
       />
-      <input
-        type="submit"
-        disabled={Boolean(errors?.posts?.type)}
-        value="投稿"
-        className="input"
-      />
+      <div className="buttonwrap">
+        {/* <input type="reset" value="リセット" /> */}
+        <input
+          type="submit"
+          disabled={Boolean(errors?.posts?.type)}
+          value="投稿"
+        />
+      </div>
       {errors?.posts?.type === 'required' && <p>投稿を入力してください</p>}
       {errors?.posts?.type === 'maxLength' && (
         <p>文字数は140文字以下にしてください</p>

--- a/src/PostsListContainer.js
+++ b/src/PostsListContainer.js
@@ -2,6 +2,7 @@ import React, { useReducer } from 'react';
 import axios from 'axios';
 import { useParams } from 'react-router-dom';
 import { Posts } from './Posts';
+import { CommentForm } from './CommentForm';
 const baseUrl = process.env.REACT_APP_BASEURL;
 
 const postsListReducer = (state, action) => {
@@ -54,9 +55,12 @@ export const PostsListContainer = () => {
   const state = useFetchPosts(threadId);
 
   return (
-    <main className="main">
-      <h3>全てのコメント</h3>
-      <Posts state={state} />
-    </main>
+    <div className="post-form">
+      <main className="main">
+        <h3>全てのコメント</h3>
+        <Posts state={state} />
+      </main>
+      <CommentForm threadId={threadId} />
+    </div>
   );
 };

--- a/src/PostsListContainer.js
+++ b/src/PostsListContainer.js
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, useCallback } from 'react';
 import axios from 'axios';
 import { useParams } from 'react-router-dom';
 import { Posts } from './Posts';
@@ -31,7 +31,7 @@ const useFetchPosts = (threadId) => {
     loading: true,
     error: null,
   });
-  React.useEffect(() => {
+  const fetchPosts = useCallback(() => {
     axios
       .get(`${baseUrl}/threads/${threadId}/posts?offset=0`)
       .then((res) => {
@@ -47,12 +47,20 @@ const useFetchPosts = (threadId) => {
         });
       });
   }, [threadId]);
-  return state;
+
+  React.useEffect(() => {
+    fetchPosts();
+  }, [fetchPosts]);
+
+  return { state, fetchPosts };
 };
 
 export const PostsListContainer = () => {
   const { threadId } = useParams();
-  const state = useFetchPosts(threadId);
+  const { state, fetchPosts } = useFetchPosts(threadId);
+  const fetchPostsList = useCallback(() => {
+    fetchPosts();
+  }, [fetchPosts]);
 
   return (
     <div className="post-form">
@@ -60,7 +68,7 @@ export const PostsListContainer = () => {
         <h3>全てのコメント</h3>
         <Posts state={state} />
       </main>
-      <CommentForm threadId={threadId} />
+      <CommentForm threadId={threadId} fetchPostsList={fetchPostsList} />
     </div>
   );
 };

--- a/src/PostsListContainer.js
+++ b/src/PostsListContainer.js
@@ -58,6 +58,7 @@ const useFetchPosts = (threadId) => {
 export const PostsListContainer = () => {
   const { threadId } = useParams();
   const { state, fetchPosts } = useFetchPosts(threadId);
+  // コメント投稿後にコメント一覧を更新
   const fetchPostsList = useCallback(() => {
     fetchPosts();
   }, [fetchPosts]);

--- a/src/PostsListContainer.js
+++ b/src/PostsListContainer.js
@@ -60,7 +60,7 @@ export const PostsListContainer = () => {
         <h3>全てのコメント</h3>
         <Posts state={state} />
       </main>
-      <CommentForm threadId={threadId} fetchPostsList={fetchPosts} />
+      <CommentForm threadId={threadId} updatePostsList={fetchPosts} />
     </div>
   );
 };

--- a/src/PostsListContainer.js
+++ b/src/PostsListContainer.js
@@ -1,4 +1,4 @@
-import React, { useReducer, useCallback } from 'react';
+import React, { useReducer } from 'react';
 import axios from 'axios';
 import { useParams } from 'react-router-dom';
 import { Posts } from './Posts';
@@ -31,26 +31,21 @@ const useFetchPosts = (threadId) => {
     loading: true,
     error: null,
   });
-  const fetchPosts = useCallback(() => {
-    axios
-      .get(`${baseUrl}/threads/${threadId}/posts?offset=0`)
-      .then((res) => {
-        dispatch({
-          type: 'SUCCESS',
-          payload: { posts: res.data.posts || [] },
-        });
-      })
-      .catch((error) => {
-        dispatch({
-          type: 'ERROR',
-          payload: { error },
-        });
-      });
-  }, [threadId]);
+
+  const fetchPosts = async () => {
+    try {
+      const res = await axios.get(
+        `${baseUrl}/threads/${threadId}/posts?offset=0`,
+      );
+      dispatch({ type: 'SUCCESS', payload: { posts: res.data.posts || [] } });
+    } catch (error) {
+      dispatch({ type: 'ERROR', payload: { error } });
+    }
+  };
 
   React.useEffect(() => {
     fetchPosts();
-  }, [fetchPosts]);
+  }, []);
 
   return { state, fetchPosts };
 };
@@ -58,10 +53,6 @@ const useFetchPosts = (threadId) => {
 export const PostsListContainer = () => {
   const { threadId } = useParams();
   const { state, fetchPosts } = useFetchPosts(threadId);
-  // コメント投稿後にコメント一覧を更新
-  const fetchPostsList = useCallback(() => {
-    fetchPosts();
-  }, [fetchPosts]);
 
   return (
     <div className="post-form">
@@ -69,7 +60,7 @@ export const PostsListContainer = () => {
         <h3>全てのコメント</h3>
         <Posts state={state} />
       </main>
-      <CommentForm threadId={threadId} fetchPostsList={fetchPostsList} />
+      <CommentForm threadId={threadId} fetchPostsList={fetchPosts} />
     </div>
   );
 };


### PR DESCRIPTION
## 実装内容

投稿一覧ページに投稿新規作成用のフォームを追加する


## 詳細

- 投稿ボタンを押下した場合、入力した文字列が投稿一覧に表示される
- 投稿がない場合、「投稿を入力してください」を表示
- 投稿が140文字を超えた場合、「文字数は140文字以下にしてください」を表示
- リセットボタンを押下した場合、テキストエリアに入力した文字列が空になる


## 工夫

1. バリデーション：
    - 何も入力されていない場合はバリデーションメッセージが表示される
    - 140文字を超えた場合はバリデーションメッセージが表示される
1. 更新されるコンポーネントの最適化：投稿ボタンを押下後、画面全体のリロードをせず投稿一覧のAPIのみを実行して更新
1. コードの可読性：React hook formでバリデーションメッセージとのロジックを分離
1. ~~投稿の並び順：新しいコメントが上から順番に追加されるように修正~~→投稿データに日時の値が紐づいていないAPI側の修正が必要なため断念


## 課題以外でのチャレンジ

- React hook formの使用
- validationの実装

## 実際の画面

https://gyazo.com/a17dd2e4b9ce304880e94102eeb80203

課題URL：https://techtrain.dev/mypage/railway/23/station/170
